### PR TITLE
Add social authentication to the site

### DIFF
--- a/bookmarks/account/templates/registration/login.html
+++ b/bookmarks/account/templates/registration/login.html
@@ -22,4 +22,12 @@
         </form>
         <p><a href="{% url "password_reset" %}">Forgotten your password?</a></p>
     </div>
+    <div class="social">
+    <ul>
+        <li class="facebook">
+        <a href="{% url "social:begin" "facebook" %}">Sign in with
+       Facebook</a>
+        </li>
+    </ul>
+    </div>
 {% endblock %}

--- a/bookmarks/account/templates/registration/login.html
+++ b/bookmarks/account/templates/registration/login.html
@@ -24,6 +24,8 @@
     </div>
     <div class="social">
     <ul>
+        <li class="google">
+            <a href="{% url "social:begin" "google-oauth2" %}">Login with Google</a></li>
         <li class="facebook">
         <a href="{% url "social:begin" "facebook" %}">Sign in with
        Facebook</a>

--- a/bookmarks/bookmarks/settings.py
+++ b/bookmarks/bookmarks/settings.py
@@ -112,6 +112,8 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "social_core.backends.facebook.FacebookOAuth2",
+    "social_core.backends.twitter.TwitterOAuth",
+    "social_core.backends.google.GoogleOAuth2",
 ]
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
@@ -138,6 +140,9 @@ STATIC_URL = "/static/"
 SOCIAL_AUTH_FACEBOOK_KEY = env("SOCIAL_AUTH_FACEBOOK_KEY")  # Facebook App ID
 SOCIAL_AUTH_FACEBOOK_SECRET = env("SOCIAL_AUTH_FACEBOOK_SECRET")
 SOCIAL_AUTH_FACEBOOK_SCOPE = ["email"]
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = env("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = env("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/bookmarks/bookmarks/settings.py
+++ b/bookmarks/bookmarks/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = (
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["mysite.com", "localhost", "127.0.0.1"]
 
 
 # Application definition
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_extensions",
 ]
 
 MIDDLEWARE = [

--- a/bookmarks/bookmarks/settings.py
+++ b/bookmarks/bookmarks/settings.py
@@ -12,6 +12,10 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 import os
 from pathlib import Path
+import environ
+
+env = environ.Env()
+environ.Env.read_env()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -42,6 +46,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
+    "social_django",
 ]
 
 MIDDLEWARE = [
@@ -104,7 +109,10 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.ModelBackend",
+    "social_core.backends.facebook.FacebookOAuth2",
+]
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
@@ -126,6 +134,10 @@ STATIC_URL = "/static/"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
+
+SOCIAL_AUTH_FACEBOOK_KEY = env("SOCIAL_AUTH_FACEBOOK_KEY")  # Facebook App ID
+SOCIAL_AUTH_FACEBOOK_SECRET = env("SOCIAL_AUTH_FACEBOOK_SECRET")
+SOCIAL_AUTH_FACEBOOK_SCOPE = ["email"]
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/bookmarks/bookmarks/urls.py
+++ b/bookmarks/bookmarks/urls.py
@@ -21,6 +21,7 @@ from django.conf.urls.static import static
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("account/", include("account.urls")),
+    path("social-auth/", include("social_django.urls", namespace="social")),
 ]
 if settings.DEBUG:
     urlpatterns += static(


### PR DESCRIPTION
- Installed the django_extensions library to run the Django development server on Https because social authentication method requires an HTTPS connection.
- installed social-auth-app-django library to make social authentication easier for users.
- Used the django-environ library to hide the environmental variables from others.