### PR TITLE
Display image thumbnails

### DIFF
--- a/bookmarks/bookmarks/settings.py
+++ b/bookmarks/bookmarks/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django_extensions",
     "social_django",
+    "easy_thumbnails",
 ]
 
 MIDDLEWARE = [

--- a/bookmarks/images/templates/images/image/detail.html
+++ b/bookmarks/images/templates/images/image/detail.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
+{% load thumbnail %}
 
 {% block title %}{{ image.title }}{% endblock %}
 
 {% block content %}
   <h1>{{ image.title }}</h1>
-  <img src="{{ image.image.url }}" class="image-detail">
+  <a href="{{ image.image.url }}">
+  <img src="{% thumbnail image.image 300x0 %}" class="image-detail">
+  </a>
   
   {% with total_likes=image.users_like.count users_like=image.users_like.all %}
     <div class="image-info">


### PR DESCRIPTION
- Installed the easy_thumbnails library to display optimized images in a uniform way is to generate thumbnails.
- displayed image thumbnails because original files for some images may be huge, and loading them might take too long.